### PR TITLE
Add UTC time, add upcoming events

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Meeting Time
 
-CNCF's Telecom User Group on the first and third Mondays of the month at 8AM PT (USA and Canada)
+CNCF's Telecom User Group on the first and third Mondays of the month at 8AM PT (16:00 UTC)
 
 Join Zoom Meeting:  https://zoom.us/j/297749799
 
@@ -17,7 +17,7 @@ Meeting ID: 297 749 799
 
 Find your local number: https://zoom.us/u/acX94Wyyaj
 
-- **Next zoom call: Monday, June 17th at 8AM PT**
+- **Next zoom call: Monday, July 15th at 8AM PT (16:00 UTC)**
  
 ## Meeting Minutes
 Upcoming and past meeting agenda/notes are [available](https://docs.google.com/document/d/1yhtI7aiwpdAiRBKyUX6mOJDHAbjOog2mI4Ur2k27D7s/edit#)
@@ -30,11 +30,20 @@ Upcoming and past meeting agenda/notes are [available](https://docs.google.com/d
 
 ## Upcoming Events: 
 
+### TUG + CNFs At Open Networking Summit EU 2019
+
+Monday, September 23 • TBD - [Half-day Telecom User Group Event](https://events.linuxfoundation.org/events/open-networking-summit-europe-2019/)
+
+### TUG + CNFs At KubeCon + CloudNativeCon NA 2019
+
+Tuesday, Nov 19 • TBD - [Intro + Deep Dive BoF: Telecom User Group and Cloud Native Network Functions (CNF) Testbed - Cheryl Hung, Dan Kohn, CNCF & Taylor Carpenter, Vulk Coop](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/register/)
+
+## Past Events:
+
 ### CNFs At KubeCon + CloudNativeCon China 2019
 
 Tuesday, June 25 • 11:20 - 11:55am - [Intro + Deep Dive BoF: Telecom User Group and Cloud Native Network Functions (CNF) Testbed - Cheryl Hung, Dan Kohn, CNCF & Taylor Carpenter, Vulk Coop](https://sched.co/OBhN)
 
-## Past Events:
 **Kickoff meeting at KubeCon EU on Thursday, May 23 • 11:05am - 12:30pm** - [Intro + Deep Dive BoF: Telecom User Group and Cloud Native Network Functions (CNF) Testbed - Cheryl Hung, Dan Kohn, CNCF & Taylor Carpenter, Vulk Coop](https://sched.co/MSzj)
 - [Video](https://www.youtube.com/watch?v=zEIr1mq-81E)
 - [Slides](https://docs.google.com/presentation/d/1iAgzRp5eFv7LWmpR2u1Wy0LdhvB85SkKJBxXFSNH8XE/)


### PR DESCRIPTION
Action items from TUG BoF: 

- add "next meeting on July 15"
- add UTC time to readme
- add upcoming events at ONS and KubeCon
