### PR TITLE
CNCF TUG & CNTT Agenda URL added

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Meeting ID: 297 749 799
 
 Find your local number: https://zoom.us/u/acX94Wyyaj
 
-- **Next zoom call: Monday, November 4th at 3:00 - 4:00 PM UTC (8:00 - 9:00 AM Pacific Time) **
+- **Next zoom call: Monday, November 4th at 3:00 - 4:00 PM UTC (8:00 - 9:00 AM Pacific Time)**
  
 ## Meeting Minutes
 Upcoming and past meeting agenda/notes are [available](https://docs.google.com/document/d/1yhtI7aiwpdAiRBKyUX6mOJDHAbjOog2mI4Ur2k27D7s/edit#)
@@ -35,16 +35,17 @@ TUG meeting recordings are available on [CNCF's YouTube Channel](https://www.you
 
  ### TUG + CNFs At KubeCon + CloudNativeCon NA 2019
 
-Monday, November 18 • 4:30pm - 6:30pm - CNCF TUG & CNTT: Part 1 
-  - Location: Meeting room 17B, Mezzanine level, SDCC
-  - No event URL
+Monday, November 18 • 4:30pm - 6:30pm - [CNCF TUG & CNTT: Part 1](https://wiki.lfnetworking.org/display/LN/CNTT+-+CNCF+TUG+F2F+workshop+in+KubeCon+NA+2019#CNTT-CNCFTUGF2FworkshopinKubeConNA2019-Brainstormingagendaitems) 
+  - Location: Meeting room 17B, Mezzanine level, San Diego Convention Center
+  - Details: AV in the room, set theater, capacity 100
+  - [Agenda](https://wiki.lfnetworking.org/display/LN/CNTT+-+CNCF+TUG+F2F+workshop+in+KubeCon+NA+2019#CNTT-CNCFTUGF2FworkshopinKubeConNA2019-Brainstormingagendaitems)
 
 Wednesday, November 20 • 3:20pm - 3:55pm - [Birds of a Feather: Telecom User Group - Cheryl Hung, Dan Kohn, Cloud Native Computing Foundation; & Taylor Carpenter, Vulk Coop](https://sched.co/Uakt)
 
-Wednesday, November 20 • 4pm - 6pm - CNCF TUG & CNTT: Part 2
+Wednesday, November 20 • 4pm - 6pm - [CNCF TUG & CNTT: Part 2](https://wiki.lfnetworking.org/display/LN/CNTT+-+CNCF+TUG+F2F+workshop+in+KubeCon+NA+2019#CNTT-CNCFTUGF2FworkshopinKubeConNA2019-Brainstormingagendaitems)
   - Location: Meeting room 2, Upper level, SDCC
   - Details: AV in the room, set round tables, capacity 160
-  - No event URL
+  - [Agenda](https://wiki.lfnetworking.org/display/LN/CNTT+-+CNCF+TUG+F2F+workshop+in+KubeCon+NA+2019#CNTT-CNCFTUGF2FworkshopinKubeConNA2019-Brainstormingagendaitems)
 
 Thursday, November 21 • 4:25pm - 5:55pm - [Intro + Deep Dive: Cloud Native Network Function (CNF) Testbed](https://sched.co/UakA)
 


### PR DESCRIPTION
We're seeking suggestions on agenda items which we plan to set early next week.  

Please add them to the wiki page: 
 https://wiki.lfnetworking.org/display/LN/CNTT+-+CNCF+TUG+F2F+workshop+in+KubeCon+NA+2019#CNTT-CNCFTUGF2FworkshopinKubeConNA2019-Brainstormingagendaitems