### PR TITLE
update meeting time, next meeting on June 1st

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 
 ## Meeting Time
 
-CNCF's Telecom User Group on the first Monday of the month at 15:00 UTC (8:00 AM Pacific Time) and the third Monday of the month at 11:00 UTC (7:00 PM China Standard Time)
+CNCF's Telecom User Group meets on the first Monday of the month. The meeting time switches monthly between:
+- 15:00 UTC (8am Pacific Time)
+- 11:00 UTC (7pm China Standard Time)
+
 
 Join Zoom Meeting:  https://zoom.us/j/297749799
 
@@ -17,7 +20,7 @@ Meeting ID: 297 749 799
 
 Find your local number: https://zoom.us/u/acX94Wyyaj
 
-- **Next zoom call: Monday, May 18th at 11:00 UTC (7:00 PM China Standard Time)**  
+- **Next zoom call: Monday, June 1st at 15:00 UTC (8:00 AM Pacific Time)**  
  
 ## Meeting Minutes
 Upcoming and past meeting agenda/notes are [available](https://docs.google.com/document/d/1yhtI7aiwpdAiRBKyUX6mOJDHAbjOog2mI4Ur2k27D7s/edit#)


### PR DESCRIPTION
CNCF's Telecom User Group meets on the first Monday of the month. The meeting time switches monthly between:
- 15:00 UTC (8am Pacific Time)
- 11:00 UTC (7pm China Standard Time)

- **Next zoom call: Monday, June 1st at 15:00 UTC (8:00 AM Pacific Time)**