### PR TITLE
Update next meeting date/time, upcoming events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Meeting ID: 297 749 799
 
 Find your local number: https://zoom.us/u/acX94Wyyaj
 
-- **Next zoom call: Monday, September 7th at 11:00 UTC (7pm China Standard Time)**  
+- **Next zoom call: Monday, October 5th at 15:00 UTC (8am Pacific Time)**  
  
 ## Meeting Minutes
 Upcoming and past meeting agenda/notes are [available](https://docs.google.com/document/d/1yhtI7aiwpdAiRBKyUX6mOJDHAbjOog2mI4Ur2k27D7s/edit#)
@@ -38,6 +38,8 @@ TUG meeting recordings are available on [CNCF's YouTube Channel](https://www.you
 
 ### [TUG + CNFs At Open Networking & Edge Summit NA 2020](https://events.linuxfoundation.org/open-networking-edge-summit-north-america/)
 
+Monday, September 28 • 18:00 - 21:00 UTC - [Tutorial: Cloud Native for Edge and Service Providers - Sponsored by Cloud Native Computing Foundation (Pre-registration Required)](https://sched.co/bWhI)
+
 Wednesday, September 30 • 17:45 - 18:15 UTC - [Birds of a Feather: CNCF Telecom User Group](https://sched.co/bWQV)
 
 Wednesday, September 30 • 17:45 - 18:15 UTC - [Panel Discussion: Cloud Native Thinking for Telecommunications Chapter 1](https://sched.co/bWQh)
@@ -45,18 +47,18 @@ Wednesday, September 30 • 17:45 - 18:15 UTC - [Panel Discussion: Cloud Native 
 
 ### [TUG + CNFs At KubeCon + CloudNativeCon NA 2020](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/)
 
-TBD 
+TBD - Schedule Announcement: Thursday, October 1, 2020
 
 
 ## Past Events:
 
-### [TUG + CNFs At Cloud Native + Open Source Virtual Summit China 2020](https://cncf.lfasiallc.cn/)
-
-Saturday, August 1 • 12:10 - 12:40 UTC - [Intro: Birds of a Feather: Telecom User Group](https://sched.co/cpAM)
-
 ### [TUG + CNFs At KubeCon + CloudNativeCon EU 2020](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-europe-2020/)
 
 Wednesday, August 19 • 14:55 - 15:30 UTC - [Birds of a Feather: Telecom User Group](https://sched.co/Zevr)
+
+### [TUG + CNFs At Cloud Native + Open Source Virtual Summit China 2020](https://cncf.lfasiallc.cn/)
+
+Saturday, August 1 • 12:10 - 12:40 UTC - [Intro: Birds of a Feather: Telecom User Group](https://sched.co/cpAM)
 
 ### [CNTT April 2020 Virtual Technical Event](https://wiki.lfnetworking.org/display/LN/2020+April+Virtual+Technical+Event)
 


### PR DESCRIPTION
- **Next zoom call: Monday, October 5th at 15:00 UTC (8am Pacific Time)**  

- Monday, September 28 • 18:00 - 21:00 UTC - [Tutorial: Cloud Native for Edge and Service Providers - Sponsored by Cloud Native Computing Foundation (Pre-registration Required)](https://sched.co/bWhI)