### PR TITLE
New meeting time for Mar 1 - 15:00 UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Meeting ID: 297 749 799
 
 Find your local number: https://zoom.us/u/acX94Wyyaj
 
-- **Next zoom call: Monday, March 1st at 11:00 UTC**  
+- **Next zoom call: Monday, March 1st at 15:00 UTC**  
  
 ## Meeting Minutes
 Upcoming and past meeting agenda/notes are [available](https://docs.google.com/document/d/1yhtI7aiwpdAiRBKyUX6mOJDHAbjOog2mI4Ur2k27D7s/edit#)


### PR DESCRIPTION
Based on the results of the doodle poll at https://doodle.com/poll/cmaghxwtw6nrq9yx, the TUG meeting time on Mon, March 1 will be 15:00 UTC (not 11:00 UTC)

