### PR TITLE
next meeting time & cnf wg at kubecon eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Meeting Time
 
 CNCF's Telecom User Group meets on the first Monday of the month. The meeting time switches monthly between:
-- 15:00 UTC (7am Pacific Time)
+- 15:00 UTC (8am Pacific Daylight Time)
 - 11:00 UTC (7pm China Standard Time)
 
 
@@ -21,7 +21,7 @@ Meeting ID: 297 749 799
 
 Find your local number: https://zoom.us/u/acX94Wyyaj
 
-- **Next zoom call: Monday, March 1st at 15:00 UTC**  
+- **Next zoom call: Monday, April 5th at 15:00 UTC**  
  
 ## Meeting Minutes
 Upcoming and past meeting agenda/notes are [available](https://docs.google.com/document/d/1yhtI7aiwpdAiRBKyUX6mOJDHAbjOog2mI4Ur2k27D7s/edit#)
@@ -39,7 +39,10 @@ TUG meeting recordings are available on [CNCF's YouTube Channel](https://www.you
 
 ### [TUG + CNFs At KubeCon + CloudNativeCon EU 2021 Virtual](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/)
 
-TBD: May 4 - 7, 2021
+[CNF WG: K8s Best Practices for Telco Apps](https://sched.co/iE74) at KubeCon EU 2021
+- Thursday, May 6 at 11:30 - 12:05 UTC
+- [Register](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/)
+
 
 
 ## Past Events:


### PR DESCRIPTION
**Next zoom call: Monday, April 5th at 15:00 UTC**  

Upcoming events:

[CNF WG: K8s Best Practices for Telco Apps](https://sched.co/iE74) at KubeCon EU 2021
- Thursday, May 6 at 11:30 - 12:05 UTC
- [Register](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/)